### PR TITLE
Set up CircleCI, build and tag Docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,13 @@
+version: 2.1
+
+orbs:
+  docker-publish: circleci/docker-publish@0.1.6
+
+workflows:
+  build_and_publish:
+    jobs:
+      - docker-publish/publish:
+          context: quay.io
+          registry: quay.io
+          image: upennlibraries/alma-webhook
+          tag: circleci.${CIRCLE_BUILD_NUM}


### PR DESCRIPTION
This will run CircleCI to build and publish the Docker image to Quay! 🎉 