### PR TITLE
Use Git hashes for Docker tags and smoke test image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,19 @@ version: 2.1
 orbs:
   docker-publish: circleci/docker-publish@0.1.6
 
+jobs:
+  test:
+    docker:
+      - image: circleci/ruby:2.6.1
+      - image: quay.io/upennlibraries/alma-webhook:${CIRCLE_SHA1}
+    steps:
+      - run:
+          name: Smoke Test Container
+          command: |
+            wget \
+              -q -t 5 --retry-connrefused -O /dev/null \
+              http://localhost:80/
+
 workflows:
   build_and_publish:
     jobs:
@@ -21,3 +34,6 @@ workflows:
             --label "edu.upenn.library.circleci.git-commit=${CIRCLE_SHA1}"
             --label "edu.upenn.library.circleci.git-repo-url=${CIRCLE_REPOSITORY_URL}"
             --label "edu.upenn.library.circleci.workflow-id=${CIRCLE_WORKFLOW_ID}"
+      - test:
+          requires:
+            - docker-publish/publish

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,4 +10,14 @@ workflows:
           context: quay.io
           registry: quay.io
           image: upennlibraries/alma-webhook
-          tag: circleci.${CIRCLE_BUILD_NUM}
+          tag: ${CIRCLE_SHA1}
+          extra_build_args: >-
+            -t quay.io/upennlibraries/alma-webhook:${CIRCLE_SHA1:0:7}
+            --label "edu.upenn.library.build-system=circleci"
+            --label "edu.upenn.library.circleci.build-number=${CIRCLE_BUILD_NUM}"
+            --label "edu.upenn.library.circleci.build-timestamp=$(date -uIs)"
+            --label "edu.upenn.library.circleci.build-url=${CIRCLE_BUILD_URL}"
+            --label "edu.upenn.library.circleci.git-branch=${CIRCLE_BRANCH}"
+            --label "edu.upenn.library.circleci.git-commit=${CIRCLE_SHA1}"
+            --label "edu.upenn.library.circleci.git-repo-url=${CIRCLE_REPOSITORY_URL}"
+            --label "edu.upenn.library.circleci.workflow-id=${CIRCLE_WORKFLOW_ID}"


### PR DESCRIPTION
We can use Git hashes for our Docker images instead of branch name tags. I've labeled the image with a bunch of metadata that could be useful while debugging. I've also set up a smoke test to verify that the application can serve up a response. 🏷 