### PR TITLE
Audit repo for secrets with gitleaks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,15 @@ orbs:
   docker-publish: circleci/docker-publish@0.1.6
 
 jobs:
+  gitleaks:
+    docker:
+      - image: quay.io/upennlibraries/gitleaks:v1.23.0
+    steps:
+      - run:
+          name: Audit Repository for Secrets
+          command: |
+            git clone https://github.com/upenn-libraries/alma-webhook.git /root/project
+            gitleaks --repo-path=/root/project --redact --repo-config
   test:
     docker:
       - image: circleci/ruby:2.6.1
@@ -19,6 +28,7 @@ jobs:
 workflows:
   build_and_publish:
     jobs:
+      - gitleaks
       - docker-publish/publish:
           context: quay.io
           registry: quay.io


### PR DESCRIPTION
Gitleaks will now run against a cloned version of the repo to check for any credentials that were committed accidentally.

The CircleCI checkout command just pulls down files and not Git commit history so we're manually doing a full clone instead. We can run Gitleaks against smaller or more focused changesets in the future, but for now it runs faster than the build so it's not a bottleneck. 🍾