### PR TITLE
Use upenn-libraries/docker-publish orb to build Docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  docker-publish: circleci/docker-publish@0.1.6
+  docker-publish: upenn-libraries/docker-publish@0.1.0
   gitleaks: upenn-libraries/gitleaks@0.1.0
 
 jobs:
@@ -27,17 +27,7 @@ workflows:
           context: quay.io
           registry: quay.io
           image: upennlibraries/alma-webhook
-          tag: ${CIRCLE_SHA1}
-          extra_build_args: >-
-            -t quay.io/upennlibraries/alma-webhook:${CIRCLE_SHA1:0:7}
-            --label "edu.upenn.library.build-system=circleci"
-            --label "edu.upenn.library.circleci.build-number=${CIRCLE_BUILD_NUM}"
-            --label "edu.upenn.library.circleci.build-timestamp=$(date -uIs)"
-            --label "edu.upenn.library.circleci.build-url=${CIRCLE_BUILD_URL}"
-            --label "edu.upenn.library.circleci.git-branch=${CIRCLE_BRANCH}"
-            --label "edu.upenn.library.circleci.git-commit=${CIRCLE_SHA1}"
-            --label "edu.upenn.library.circleci.git-repo-url=${CIRCLE_REPOSITORY_URL}"
-            --label "edu.upenn.library.circleci.workflow-id=${CIRCLE_WORKFLOW_ID}"
+          label_prefix: edu.upenn.library
       - test:
           requires:
             - docker-publish/publish


### PR DESCRIPTION
We can cut down on the amount of config we need to copy from project to project by using our published [Docker publishing Orb](https://github.com/upenn-libraries/circleci_orb_docker_publish). ⚾️ 